### PR TITLE
added requirement for sha1sum on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ installation is necessary even if you're building Kubernetes from
 source. If you want you can overridde this behavior by setting
 `KUBEADM_DIND_LOCAL` to a non-empty value in [config.sh](config.sh).
 
+### Mac OS X considerations
+
+Ensure to have `md5sha1sum` installed. If not existing can be installed via `brew install md5sha1sum`.
+
 When building Kubernetes from source on Mac OS X, it should be
 possible to build `kubectl` locally, i.e. `make WHAT=cmd/kubectl` must
 work.


### PR DESCRIPTION
When running on Mac if you don't have sha1sum available the following error will happen:

```
Unable to find image 'busybox:1.26.2' locally
1.26.2: Pulling from library/busybox
27144aa8f1b9: Pull complete 
Digest: sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642
Status: Downloaded newer image for busybox:1.26.2
./dind-cluster-v1.6.sh: line 322: sha1sum: command not found
```

This comment adds the requirement to the README